### PR TITLE
add rwn optimizations for volante

### DIFF
--- a/clusters/overlays/volante/kustomization.yaml
+++ b/clusters/overlays/volante/kustomization.yaml
@@ -3,4 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 bases:
+  - ../../../components/apps/rwn-optimizations
   - ../../../components/apps/sriov-operator

--- a/components/apps/rwn-optimizations/config-ingress.yaml
+++ b/components/apps/rwn-optimizations/config-ingress.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: default
+  namespace: openshift-ingress-operator
+spec:
+  nodePlacement:
+    nodeSelector:
+      matchLabels:
+        node-role.kubernetes.io/master: ""
+  replicas: 3

--- a/components/apps/rwn-optimizations/kustomization.yaml
+++ b/components/apps/rwn-optimizations/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - config-ingress.yaml
+  - master-schedulable.yaml
+  - max-pods-500.yaml
+  - worker-fix-ipi-rwn.yaml

--- a/components/apps/rwn-optimizations/master-schedulable.yaml
+++ b/components/apps/rwn-optimizations/master-schedulable.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: config.openshift.io/v1
+kind: Scheduler
+metadata:
+  name: cluster
+spec:
+  mastersSchedulable: true

--- a/components/apps/rwn-optimizations/max-pods-500.yaml
+++ b/components/apps/rwn-optimizations/max-pods-500.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: max-pods-500
+spec:
+  machineConfigPoolSelector:
+    matchLabels:
+      custom-kubelet: max-pods-500
+  kubeletConfig:
+    podsPerCore: 0
+    maxPods: 500

--- a/components/apps/rwn-optimizations/worker-fix-ipi-rwn.yaml
+++ b/components/apps/rwn-optimizations/worker-fix-ipi-rwn.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 50-worker-fix-ipi-rwn
+  labels:
+    machineconfiguration.openshift.io/role: worker
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+        - contents:
+            source: data:,
+            verification: {}
+          filesystem: root
+          mode: 420
+          path: /etc/kubernetes/manifests/keepalived.yaml
+        - contents:
+            source: data:,
+            verification: {}
+          filesystem: root
+          mode: 420
+          path: /etc/kubernetes/manifests/mdns-publisher.yaml
+        - contents:
+            source: data:,
+            verification: {}
+          filesystem: root
+          mode: 420
+          path: /etc/kubernetes/manifests/coredns.yaml
+    systemd:
+      units:    # yamllint disable rule:line-length
+        - contents: |
+            [Unit]
+            Description=Writes IP address configuration so that kubelet and crio services select a valid node IP
+            Wants=network-online.target
+            After=network-online.target ignition-firstboot-complete.service
+            Before=kubelet.service crio.service
+            [Service]
+            Type=oneshot
+            ExecStart=/bin/bash -c "exit 0 "
+            [Install]
+            WantedBy=multi-user.target
+          enabled: true   # yamllint disable rule:line-length
+          name: nodeip-configuration.service


### PR DESCRIPTION
adds necessary customizations to volante to move ingress to the control plane, and put enhancements in to remove unnecessary pods from workers.  Noticed when upgrading the cluster from 4.10.18 to 4.10.30.